### PR TITLE
add secrets to setup, fix config.py path in app

### DIFF
--- a/src/clabaireacht/__init__.py
+++ b/src/clabaireacht/__init__.py
@@ -26,10 +26,11 @@ def create_app(test_config=None):
 
     # Load production configuration, if it exists, when not testing
     if test_config is None:
-        clabaireacht.config.from_pyfile("config.py", silent=True)
+        clabaireacht.config.from_pyfile("../config.py", silent=True)
     else:
         clabaireacht.config.from_mapping(test_config)
 
+    print(clabaireacht.config)
     # ensure the instance folder exists
     try:
         os.makedirs(clabaireacht.instance_path, mode=0o700)


### PR DESCRIPTION
sets up secrets for use in production.
ronie@debian:~/Masters/SPW/Group6_web_app/src$ python setup.py --production
config.py exists, do you want to continue and modify it? [y/N]: y
Create new Session Cookie Secret Key? [y/N]: y
Create new Password Pepper. NB: all previously saved passwords will be lost. [y/N]: y
(Group6_web_app-aBsMno69) ronie@debian:~/Masters/SPW/Group6_web_app/src$ cat config.py
SECRET_KEY = "0825198b17cdbdbdc39f06fc306ec37721f23f88aa64f098f34a3f7bc63edc6c"
PW_PEPPER_SECRET = "f07dc93a78c29c822df5bd32947c4c03"